### PR TITLE
fix: replace pyaga8 panic paths with Python exceptions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyaga8"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -1,19 +1,45 @@
 # pyaga8
-Python package for calculating gas properties using the AGA8 equations GERG-2008 and DETAIL, utilizing the Rust port ((https://crates.io/crates/aga8) of NIST's AGA8 code (https://github.com/usnistgov/AGA8).
 
-Link to Github repo: https://github.com/equinor/pyaga8
+Python bindings for the AGA8 GERG-2008 and DETAIL gas property equations, built on the Rust [`aga8`](https://crates.io/crates/aga8) port of NIST's AGA8 code.
+
+GitHub: https://github.com/equinor/pyaga8
 
 ## Description
 
-`pyaga8` is a Python package that provides bindings for the AGA8 algorithm (GERG-2008 and DETAIL equations). The core functionality is implemented in Rust for performance, and it is exposed to Python using the `pyo3` library.
+`pyaga8` is a low-level Python interface to the AGA8 calculations. It exposes the underlying GERG-2008 and DETAIL state objects and methods directly, with Rust used for performance via `pyo3`.
 
-`pyaga8` is used by the `pvtlib` package: https://pypi.org/project/pvtlib/
-`pvtlib` include methods built on top of the pyaga8 functions, such as gas properties from PT (pressure, temperature), PH (pressure, enthalpy), PS (pressure, entropy) and rhoT (density, temperature). 
-Link to example: https://github.com/equinor/pvtlib/blob/main/examples/gas_properties_from_aga8.py
+Higher-level libraries such as [`pvtlib`](https://pypi.org/project/pvtlib/) build on top of `pyaga8` to provide workflows such as PT, PH, PS and rhoT calculations:
+https://github.com/equinor/pvtlib/blob/main/examples/gas_properties_from_aga8.py
 
 ## Installation
 
-You can install the package using `pip`:
-
 ```sh
 pip install pyaga8
+```
+
+## Minimal usage
+
+```python
+import pyaga8
+
+detail = pyaga8.Detail()
+comp = pyaga8.Composition()
+comp.methane = 0.9
+comp.nitrogen = 0.1
+
+detail.set_composition(comp)
+detail.temperature = 400.0
+detail.pressure = 50_000.0
+detail.calc_density()
+
+print(detail.d)
+```
+
+## Error handling
+
+Python-facing API methods raise normal Python exceptions when inputs or state are invalid; they do not intentionally panic the Python interpreter.
+
+- `set_composition(...)` raises `ValueError` for invalid mixtures, for example an empty composition or a sum that is not close enough to `1.0`.
+- `calc_density(...)` / `calc_density()` raises ordinary Python exceptions based on the underlying failure, typically `ValueError` or `RuntimeError`.
+
+`pyaga8` is intentionally a lower-level library. Higher-level packages may choose to translate selected failures to `NaN` or other domain-specific behavior, but that translation is not part of `pyaga8` itself.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,32 @@
 // SOFTWARE.
 
 
-use aga8::*;
+use aga8::composition::CompositionError;
+use aga8::{composition, detail, gerg2008, DensityError};
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
+
+/// Convert Rust-side composition errors into ordinary Python exceptions.
+fn composition_error_to_py_err(err: CompositionError) -> PyErr {
+    match err {
+        CompositionError::Empty => PyValueError::new_err("composition cannot be empty"),
+        CompositionError::BadSum => {
+            PyValueError::new_err("composition sum must be within 0.01 of 1.0")
+        }
+        CompositionError::Ok => PyRuntimeError::new_err("unexpected composition error state"),
+    }
+}
+
+/// Convert Rust-side density errors into ordinary Python exceptions.
+fn density_error_to_py_err(err: DensityError) -> PyErr {
+    match err {
+        DensityError::PressureTooLow => PyValueError::new_err("pressure is too low for density calculation"),
+        DensityError::IterationFail => {
+            PyRuntimeError::new_err("density calculation failed to converge")
+        }
+        DensityError::Ok => PyRuntimeError::new_err("unexpected density error state"),
+    }
+}
 
 #[pyclass]
 struct Gerg2008 {
@@ -147,9 +171,8 @@ impl Gerg2008 {
     }
 
     // Functions
-    // TODO: Proper error handling
-    fn calc_density(&mut self, flag: i32) {
-        self.inner.density(flag).unwrap();
+    fn calc_density(&mut self, flag: i32) -> PyResult<()> {
+        self.inner.density(flag).map_err(density_error_to_py_err)
     }
 
     fn calc_pressure(&mut self) -> f64 {
@@ -164,8 +187,10 @@ impl Gerg2008 {
         self.inner.molar_mass();
     }
 
-    fn set_composition(&mut self, comp: &Composition) {
-        self.inner.set_composition(&comp.inner).unwrap();
+    fn set_composition(&mut self, comp: &Composition) -> PyResult<()> {
+        self.inner
+            .set_composition(&comp.inner)
+            .map_err(composition_error_to_py_err)
     }
 }
 
@@ -292,9 +317,8 @@ impl Detail {
     }
 
     // Functions
-    // TODO: Proper error handling
-    fn calc_density(&mut self) {
-        self.inner.density().unwrap();
+    fn calc_density(&mut self) -> PyResult<()> {
+        self.inner.density().map_err(density_error_to_py_err)
     }
 
     fn calc_pressure(&mut self) -> f64 {
@@ -309,8 +333,10 @@ impl Detail {
         self.inner.molar_mass();
     }
 
-    fn set_composition(&mut self, comp: &Composition) {
-        self.inner.set_composition(&comp.inner).unwrap();
+    fn set_composition(&mut self, comp: &Composition) -> PyResult<()> {
+        self.inner
+            .set_composition(&comp.inner)
+            .map_err(composition_error_to_py_err)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 
 use aga8::composition::CompositionError;
 use aga8::{composition, detail, gerg2008, DensityError};
-use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use pyo3::exceptions::{PyRuntimeError, PyValueError, PyAssertionError};
 use pyo3::prelude::*;
 
 /// Convert Rust-side composition errors into ordinary Python exceptions.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ fn density_error_to_py_err(err: DensityError) -> PyErr {
         DensityError::IterationFail => {
             PyRuntimeError::new_err("density calculation failed to converge")
         }
-        DensityError::Ok => PyRuntimeError::new_err("unexpected density error state"),
+        DensityError::Ok => PyAssertionError::new_err("Not an error - should never happen"),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ fn composition_error_to_py_err(err: CompositionError) -> PyErr {
         CompositionError::BadSum => {
             PyValueError::new_err("composition sum must be within 0.01 of 1.0")
         }
-        CompositionError::Ok => PyRuntimeError::new_err("unexpected composition error state"),
+        CompositionError::Ok => PyAssertionError::new_err("Not an error - should never happen"),
     }
 }
 

--- a/tests/test_aga8.py
+++ b/tests/test_aga8.py
@@ -56,13 +56,12 @@ FULL_COMPOSITION.argon = 0.001
 def test_gerg2008_set_composition():
     gerg.set_composition(FULL_COMPOSITION)
 
-    # TODO: Map Rust Errors Empty and BadSum to python Exceptions
     invalid = pyaga8.Composition()
-    with raises(BaseException):
+    with raises(ValueError, match='composition cannot be empty'):
         gerg.set_composition(invalid)
 
     invalid.ethane = 0.3
-    with raises(BaseException):
+    with raises(ValueError, match='composition sum must be within 0.01 of 1.0'):
         gerg.set_composition(invalid)
 
 def test_gerg2008_calc_density():
@@ -72,6 +71,24 @@ def test_gerg2008_calc_density():
 
     gerg.calc_density(0)
     assert gerg.d == approx(12.798_286_260_820_62)
+
+
+def test_gerg2008_calc_density_low_pressure():
+    gerg.set_composition(FULL_COMPOSITION)
+    gerg.temperature = 400.0
+    gerg.pressure = 0.0
+
+    with raises(RuntimeError, match='density calculation failed to converge'):
+        gerg.calc_density(0)
+
+
+def test_gerg2008_calc_density_rejects_non_integer_flag():
+    gerg.set_composition(FULL_COMPOSITION)
+    gerg.temperature = 400.0
+    gerg.pressure = 50_000.0
+
+    with raises(TypeError):
+        gerg.calc_density('spam')
 
 def test_gerg2008_calc_pressure():
     gerg.set_composition(FULL_COMPOSITION)
@@ -93,6 +110,7 @@ def test_gerg2008_calc_properties():
     assert gerg.z == approx(1.174_690_666_383_717)
     assert gerg.dp_dd == approx(7_000.694_030_193_327)
     assert gerg.d2p_dd2 == approx(1_129.526_655_214_841)
+    assert gerg.d2p_dtd == approx(34.309_428_436_792_17)
     assert gerg.dp_dt == approx(235.983_229_259_309_6)
     assert gerg.u == approx(-2_746.492_901_212_53)
     assert gerg.h == approx(1_160.280_160_510_973)
@@ -135,13 +153,12 @@ def test_gerg2008_set_d():
 def test_detail_set_composition():
     detail.set_composition(FULL_COMPOSITION)
 
-    # TODO: Map Rust Errors Empty and BadSum to python Exceptions
     invalid = pyaga8.Composition()
-    with raises(BaseException):
+    with raises(ValueError, match='composition cannot be empty'):
         detail.set_composition(invalid)
 
     invalid.ethane = 0.3
-    with raises(BaseException):
+    with raises(ValueError, match='composition sum must be within 0.01 of 1.0'):
         detail.set_composition(invalid)
 
 def test_detail2008_calc_density():
@@ -151,6 +168,15 @@ def test_detail2008_calc_density():
 
     detail.calc_density()
     assert detail.d == approx(12.807_924_036_488_01)
+
+
+def test_detail2008_calc_density_low_pressure():
+    detail.set_composition(FULL_COMPOSITION)
+    detail.temperature = 400.0
+    detail.pressure = 0.0
+
+    with raises(ValueError, match='pressure is too low for density calculation'):
+        detail.calc_density()
 
 def test_detail2008_calc_pressure():
     detail.set_composition(FULL_COMPOSITION)
@@ -172,6 +198,7 @@ def test_detail2008_calc_properties():
     assert detail.z == approx(1.173_801_364_147_326)
     assert detail.dp_dd == approx(6_971.387_690_924_09)
     assert detail.d2p_dd2 == approx(1_118.803_636_639_52)
+    assert detail.d2p_dtd == approx(0.0)
     assert detail.dp_dt == approx(235.664_149_306_821_2)
     assert detail.u == approx(-2_739.134_175_817_231)
     assert detail.h == approx(1_164.699_096_269_404)


### PR DESCRIPTION
Summary

This PR hardens the Python-facing pyaga8 bindings so invalid states raise normal Python exceptions instead of panicking the interpreter.

Changes

Rust binding layer (src/lib.rs)
- Replace unwrap panic behavior in calc_density() for both Gerg2008 and Detail
- Replace unwrap panic behavior in set_composition() for both Gerg2008 and Detail
- Map underlying Rust errors to ordinary Python exceptions:
  - composition errors -> ValueError
  - density calculation failures -> ValueError / RuntimeError depending on cause

Tests (tests/test_aga8.py)
- Update composition tests to assert specific Python exceptions instead of broad panic-shaped failures
- Add explicit low-pressure failure tests for calc_density()
- Add a minimal invalid-input test for GERG calc_density(flag) type handling
- Add coverage for the exposed d2p_dtd property

Documentation (README.md)
- Expand the README with a minimal usage example
- Document the lower-level exception contract clearly
- Clarify that higher-level libraries such as pvtlib may translate selected failures to NaN, but pyaga8 itself remains explicit and exception-based

Why

pyaga8 is used by higher-level libraries such as pvtlib. Those libraries may choose to apply a NaN policy for live computations, but they cannot do that safely if the lower-level bindings panic before control returns to Python.

This PR keeps pyaga8 as an explicit lower-level library while removing interpreter-crash behavior from the Python API.

Validation

- Source and tests were updated consistently for the new exception-first contract
- Local rebuild of the Rust extension was not possible in this environment because cargo / rustc execution is blocked by group policy, so final validation must come from CI on the PR