### PR TITLE
Fix/pyo3 0.29 security

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ name = "pyaga8"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = ">=0.29.0, <0.30.0"
+pyo3 = ">=0.29.0"
 aga8 = "0.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyaga8"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -9,5 +9,5 @@ name = "pyaga8"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = "0.27.2"
+pyo3 = ">=0.29.0, <0.30.0"
 aga8 = "0.6.1"


### PR DESCRIPTION
This pull request updates the `pyaga8` package to use newer dependencies and increments its version number.

Dependency updates:

* Updated the `pyo3` dependency version requirement from `0.27.2` to `>=0.29.0` in `Cargo.toml` to allow compatibility with newer versions.

Version bump:

* Increased the package version from `0.1.17` to `0.1.18` in `Cargo.toml` to reflect the dependency update.